### PR TITLE
Fix GoLand having typo and being capitalized differently

### DIFF
--- a/jetbrains-backup.sh
+++ b/jetbrains-backup.sh
@@ -22,8 +22,8 @@ tar pf "$FILE" --append ~/Library/Preferences,Caches,Application\ Support,Logs/a
 # CLion
 tar pf "$FILE" --append ~/Library/{Preferences,Caches,Application\ Support,Logs}/{c,C}{l,L}ion{??,???,20??.*,-EAP} &>/dev/null
 
-# Gogland
-tar pf "$FILE" --append ~/Library/{Preferences,Caches,Application\ Support,Logs}/Gogland{?.?} &>/dev/null
+# GoLand
+tar pf "$FILE" --append ~/Library/{Preferences,Caches,Application\ Support,Logs}/GoLand{?.?} &>/dev/null
 
 # IntelliJ IDEA
 tar pf "$FILE" --append ~/Library/{Preferences,Caches,Application\ Support,Logs}/IntelliJIdea{??,???,20??.*,-EAP} &>/dev/null

--- a/jetbrains-uninstall.sh
+++ b/jetbrains-uninstall.sh
@@ -30,11 +30,11 @@ rm -rfv ~/Library/Caches/{c,C}{l,L}ion{??,???,20??.*,-EAP}
 rm -rfv ~/Library/Application\ Support/{c,C}{l,L}ion{??,???,20??.*,-EAP}
 rm -rfv ~/Library/Logs/{c,C}{l,L}ion{??,???,20??.*,-EAP}
 
-# Gogland
-rm -rfv ~/Library/Preferences/Gogland{?.?}
-rm -rfv ~/Library/Caches/Gogland{?.?}
-rm -rfv ~/Library/Application\ Support/Gogland{?.?}
-rm -rfv ~/Library/Logs/Gogland{?.?}
+# GoLand
+rm -rfv ~/Library/Preferences/GoLand{?.?}
+rm -rfv ~/Library/Caches/GoLand{?.?}
+rm -rfv ~/Library/Application\ Support/GoLand{?.?}
+rm -rfv ~/Library/Logs/GoLand{?.?}
 
 # IntelliJ IDEA
 rm -rfv ~/Library/Preferences/IntelliJIdea{??,???,20??.*,-EAP}


### PR DESCRIPTION
Hey Denis, thanks for the useful script!

I fixed a typo in the [GoLand](https://www.jetbrains.com/go/) name and capitalized it to match the filesystem paths. I'm also using a case-sensitive filesystem.

I tested backup and uninstall scripts on two of my workstations.